### PR TITLE
Registration via api

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The installation and deployment process is typical for a Laravel application, an
 
 Following requirements must be installed on the server for the application to work:
 
-- PHP >= 7.2
+- PHP >= 7.4
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension

--- a/app/Http/Controllers/Api/RegisterController.php
+++ b/app/Http/Controllers/Api/RegisterController.php
@@ -24,6 +24,7 @@ class RegisterController
     {
         return validator($request->all(), [
             'client_id' => ['required', Rule::exists(Client::class, 'id')->where('password_client', true)],
+            'client_secret' => ['required', 'string'],
             'first_name' => ['required', 'string', 'max:255'],
             'last_name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email:rfc,filter', 'max:255', 'unique:users'],
@@ -38,13 +39,8 @@ class RegisterController
 
             $client = Client::find($request->client_id);
 
-            $payload = $request->except('signature');
-            ksort($payload);
-
-            $expectedPayloadHmacHash = hash_hmac('sha256', json_encode($payload), $client->secret);
-
-            if (! hash_equals($expectedPayloadHmacHash, $request->signature)) {
-                $validator->errors()->add('signature', __('Invalid signature'));
+            if ($client->secret !== $request->client_secret) {
+                $validator->errors()->add('client_secret', __('Client secret is not valid.'));
             }
         })->validate();
     }

--- a/app/Http/Controllers/Api/RegisterController.php
+++ b/app/Http/Controllers/Api/RegisterController.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\License;
+use App\User;
+use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Validation\Rule;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Passport\Client;
+
+class RegisterController
+{
+    public function store(Request $request)
+    {
+        $this->validate($request);
+        $this->createUser($request);
+
+        return $this->authenticate($request);
+    }
+
+    protected function validate(Request $request)
+    {
+        return validator($request->all(), [
+            'client_id' => ['required', Rule::exists(Client::class, 'id')->where('password_client', true)],
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email:rfc,filter', 'max:255', 'unique:users'],
+            'institution' => ['nullable', 'string'],
+            'password' => ['required', 'string', 'min:8'],
+            'data_license' => ['required', Rule::in(License::activeIds())],
+            'image_license' => ['required', Rule::in(License::activeIds())],
+        ])->after(function ($validator) use ($request) {
+            if (isset($validator->failed()['client_id'])) {
+                return;
+            }
+
+            $client = Client::find($request->client_id);
+
+            $payload = $request->except('signature');
+            ksort($payload);
+
+            $expectedPayloadHmacHash = hash_hmac('sha256', json_encode($payload), $client->secret);
+
+            if (! hash_equals($expectedPayloadHmacHash, $request->signature)) {
+                $validator->errors()->add('signature', __('Invalid signature'));
+            }
+        })->validate();
+    }
+
+    protected function createUser(Request $request)
+    {
+        User::create([
+            'first_name' => $request->first_name,
+            'last_name' => $request->last_name,
+            'email' => $request->email,
+            'institution' => $request->institution,
+            'password' => Hash::make($request->password),
+            'settings' => [
+                'data_license' => (int) $request->data_license,
+                'image_license' => (int) $request->image_license,
+                'language' => app()->getLocale(),
+            ],
+        ]);
+    }
+
+    protected function authenticate(Request $request)
+    {
+        $client = Client::find($request->client_id);
+
+        return app(Kernel::class)->handle(Request::create(route('passport.token'), 'POST', [
+            'grant_type' => 'password',
+            'client_id' => $client->id,
+            'client_secret' => $client->secret,
+            'username' => $request->email,
+            'password' => $request->password,
+            'scope' => '',
+        ]));
+    }
+}

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'first_name' => ['required', 'string', 'max:255'],
             'last_name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'email' => ['required', 'string', 'email:rfc,filter', 'max:255', 'unique:users'],
             'institution' => ['nullable', 'string'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
             'captcha_verification_code' => ['required', 'captcha'],

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.5|^8.0",
+        "php": "^7.4|^8.0",
         "astrotomic/laravel-translatable": "^11.8",
         "box/spout": "^2.7",
         "doctrine/dbal": "^2.10",
@@ -53,7 +53,7 @@
         "sort-packages": true,
         "optimize-autoloader": true,
         "platform": {
-            "php": "7.3"
+            "php": "7.4"
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "86901e7474e3e5dee1e577b5bb425254",
+    "content-hash": "6a9845364f8d5166c25c944e4ae37e66",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2035,69 +2035,53 @@
             "time": "2020-11-03T19:45:19+00:00"
         },
         {
-            "name": "lcobucci/jwt",
-            "version": "3.4.5",
+            "name": "lcobucci/clock",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1"
+                "url": "https://github.com/lcobucci/clock.git",
+                "reference": "353d83fe2e6ae95745b16b3d911813df6a05bfb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/511629a54465e89a31d3d7e4cf0935feab8b14c1",
-                "reference": "511629a54465e89a31d3d7e4cf0935feab8b14c1",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/353d83fe2e6ae95745b16b3d911813df6a05bfb3",
+                "reference": "353d83fe2e6ae95745b16b3d911813df6a05bfb3",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "ext-openssl": "*",
-                "php": "^5.6 || ^7.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
-                "mikey179/vfsstream": "~1.5",
-                "phpmd/phpmd": "~2.2",
-                "phpunit/php-invoker": "~1.1",
-                "phpunit/phpunit": "^5.7 || ^7.3",
-                "squizlabs/php_codesniffer": "~2.3"
-            },
-            "suggest": {
-                "lcobucci/clock": "*"
+                "infection/infection": "^0.17",
+                "lcobucci/coding-standard": "^6.0",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/php-code-coverage": "9.1.4",
+                "phpunit/phpunit": "9.3.7"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
-                    "Lcobucci\\JWT\\": "src"
-                },
-                "files": [
-                    "compat/class-aliases.php",
-                    "compat/json-exception-polyfill.php",
-                    "compat/lcobucci-clock-polyfill.php"
-                ]
+                    "Lcobucci\\Clock\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-3-Clause"
+                "MIT"
             ],
             "authors": [
                 {
-                    "name": "Luís Otávio Cobucci Oblonczyk",
-                    "email": "lcobucci@gmail.com",
-                    "role": "Developer"
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com"
                 }
             ],
-            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
-            "keywords": [
-                "JWS",
-                "jwt"
-            ],
+            "description": "Yet another clock abstraction",
             "support": {
-                "issues": "https://github.com/lcobucci/jwt/issues",
-                "source": "https://github.com/lcobucci/jwt/tree/3.4.5"
+                "issues": "https://github.com/lcobucci/clock/issues",
+                "source": "https://github.com/lcobucci/clock/tree/2.0.x"
             },
             "funding": [
                 {
@@ -2109,7 +2093,83 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-02-16T09:40:01+00:00"
+            "time": "2020-08-27T18:56:02+00:00"
+        },
+        {
+            "name": "lcobucci/jwt",
+            "version": "4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/lcobucci/jwt.git",
+                "reference": "ae4165a76848e070fdac691e773243d10cd06ce1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/ae4165a76848e070fdac691e773243d10cd06ce1",
+                "reference": "ae4165a76848e070fdac691e773243d10cd06ce1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "lcobucci/clock": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "infection/infection": "^0.20",
+                "lcobucci/coding-standard": "^6.0",
+                "mikey179/vfsstream": "^1.6",
+                "phpbench/phpbench": "^0.17",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/php-invoker": "^3.1",
+                "phpunit/phpunit": "^9.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Lcobucci\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Luís Cobucci",
+                    "email": "lcobucci@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
+            "keywords": [
+                "JWS",
+                "jwt"
+            ],
+            "support": {
+                "issues": "https://github.com/lcobucci/jwt/issues",
+                "source": "https://github.com/lcobucci/jwt/tree/4.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/lcobucci",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/lcobucci",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2021-03-23T23:47:22+00:00"
         },
         {
             "name": "league/commonmark",
@@ -10251,11 +10311,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.5|^8.0"
+        "php": "^7.4|^8.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3"
+        "php": "7.4"
     },
     "plugin-api-version": "2.0.0"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,8 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+Route::post('register', 'RegisterController@store');
+
 Route::get('groups/{group}/taxa', 'GroupTaxaController@index')
     ->name('api.groups.taxa.index');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -241,7 +241,8 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
             ->name('api.my.field-observation-exports.store');
 
         Route::get('profile', 'ProfileController@show')
-            ->name('api.my.profile.show');
+            ->name('api.my.profile.show')
+            ->withoutMiddleware('verified');
 
         Route::post('read-notifications/batch', 'ReadNotificationsBatchController@store')
             ->name('api.my.read-notifications-batch.store');

--- a/tests/Feature/Api/RegistrationTest.php
+++ b/tests/Feature/Api/RegistrationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\License;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Passport\ClientRepository;
+use Tests\TestCase;
+
+class RegistrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected $passwordClient;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->passwordClient = app(ClientRepository::class)->createPasswordGrantClient(
+            null,
+            'Test client',
+            url('/'),
+        );
+    }
+
+    /** @test */
+    public function can_register_user_through_api()
+    {
+        $payload = [
+            'client_id' => $this->passwordClient->id,
+            'first_name' => 'Tester',
+            'last_name' => 'Testerson',
+            'data_license' => License::CC_BY_NC_SA,
+            'image_license' => License::CC_BY_NC_SA,
+            'email' => 'test@example.com',
+            'password' => 'supersecret',
+        ];
+
+        ksort($payload);
+
+        $response = $this->postJson('/api/register', array_merge($payload, [
+            'signature' => hash_hmac('sha256', json_encode($payload), $this->passwordClient->secret),
+        ]));
+
+        $this->assertNotNull($user = User::firstWhere(['email' => 'test@example.com']));
+
+        $profileResponse = $this->getJson('/api/my/profile', [
+            'Authorization' => "Bearer {$response->json('access_token')}",
+        ]);
+
+        $this->assertEquals('test@example.com', $profileResponse->json('data.email'));
+        $this->assertEquals('Tester', $profileResponse->json('data.first_name'));
+        $this->assertEquals('Testerson', $profileResponse->json('data.last_name'));
+        $this->assertEquals($user->id, $profileResponse->json('data.id'));
+    }
+
+    /** @test */
+    public function needs_valid_signature()
+    {
+        $payload = [
+            'client_id' => $this->passwordClient->id,
+            'first_name' => 'Tester',
+            'last_name' => 'Testerson',
+            'data_license' => License::CC_BY_NC_SA,
+            'image_license' => License::CC_BY_NC_SA,
+            'email' => 'test@example.com',
+            'password' => 'supersecret',
+        ];
+
+        ksort($payload);
+
+        $this->postJson('/api/register', array_merge($payload, [
+            'signature' => 'invalid',
+        ]))->assertJsonValidationErrors('signature');
+
+        $this->assertFalse(User::where('email', 'test@example.com')->exists());
+    }
+
+    /** @test */
+    public function signature_is_not_checked_if_client_is_not_valid()
+    {
+        $payload = [
+            'client_id' => 'invalid',
+            'first_name' => 'Tester',
+            'last_name' => 'Testerson',
+            'data_license' => License::CC_BY_NC_SA,
+            'image_license' => License::CC_BY_NC_SA,
+            'email' => 'test@example.com',
+            'password' => 'supersecret',
+        ];
+
+        ksort($payload);
+
+        $this->postJson('/api/register', array_merge($payload, [
+            'signature' => 'invalid',
+        ]))
+            ->assertJsonValidationErrors('client_id')
+            ->assertJsonMissingValidationErrors('signature');
+
+        $this->assertFalse(User::where('email', 'test@example.com')->exists());
+    }
+
+    /** @test */
+    public function cannot_use_client_that_is_not_password_client()
+    {
+        $client = app(ClientRepository::class)->create(
+            null,
+            'Test client',
+            url('/'),
+        );
+
+        $payload = [
+            'client_id' => $client->id,
+            'first_name' => 'Tester',
+            'last_name' => 'Testerson',
+            'data_license' => License::CC_BY_NC_SA,
+            'image_license' => License::CC_BY_NC_SA,
+            'email' => 'test@example.com',
+            'password' => 'supersecret',
+        ];
+
+        ksort($payload);
+
+        $this->postJson('/api/register', array_merge($payload, [
+            'signature' => hash_hmac('sha256', json_encode($payload), $client->secret),
+        ]))->assertJsonValidationErrors('client_id');
+
+        $this->assertFalse(User::where('email', 'test@example.com')->exists());
+    }
+}


### PR DESCRIPTION
This adds ability for 1st party clients to register new users. They need to send a request to `POST /api/register` endpoint that contains following parameters:
```
client_id: integer ID of the client
client_secret: string
first_name: string
last_name: string
data_license: integer ID of the license
image_license: integer ID the license
institution: optional, string
email: string email
password: string, min 8
```