### PR TITLE
Adjustments to publically visible data of partially open field observations 

### DIFF
--- a/app/Exports/FieldObservations/PublicFieldObservationsCustomExport.php
+++ b/app/Exports/FieldObservations/PublicFieldObservationsCustomExport.php
@@ -33,6 +33,11 @@ class PublicFieldObservationsCustomExport extends CustomFieldObservationsExport
             $transformed['accuracy'] = 5000;
         }
 
+        if ($item->license()->shouldntShowExactDate()) {
+            $transformed['month'] = null;
+            $transformed['day'] = null;
+        }
+
         return $transformed;
     }
 }

--- a/app/Exports/FieldObservations/PublicFieldObservationsCustomExport.php
+++ b/app/Exports/FieldObservations/PublicFieldObservationsCustomExport.php
@@ -28,8 +28,9 @@ class PublicFieldObservationsCustomExport extends CustomFieldObservationsExport
         $transformed = parent::transformItem($item);
 
         if ($item->shouldHideRealCoordinates()) {
-            $transformed['latitude'] = __('N/A');
-            $transformed['longitude'] = __('N/A');
+            $transformed['latitude'] = number_format($item->observation->latitude, 1);
+            $transformed['longitude'] = number_format($item->observation->longitude, 1);
+            $transformed['accuracy'] = 5000;
         }
 
         return $transformed;

--- a/app/Exports/FieldObservations/PublicFieldObservationsDarwinCoreExport.php
+++ b/app/Exports/FieldObservations/PublicFieldObservationsDarwinCoreExport.php
@@ -33,6 +33,11 @@ class PublicFieldObservationsDarwinCoreExport extends DarwinCoreFieldObservation
             $transformed['coordinateUncertaintyInMeters'] = 5000;
         }
 
+        if ($item->license()->shouldntShowExactDate()) {
+            $transformed['month'] = null;
+            $transformed['day'] = null;
+        }
+
         return $transformed;
     }
 }

--- a/app/Exports/FieldObservations/PublicFieldObservationsDarwinCoreExport.php
+++ b/app/Exports/FieldObservations/PublicFieldObservationsDarwinCoreExport.php
@@ -28,8 +28,9 @@ class PublicFieldObservationsDarwinCoreExport extends DarwinCoreFieldObservation
         $transformed = parent::transformItem($item);
 
         if ($item->shouldHideRealCoordinates()) {
-            $transformed['latitude'] = __('N/A');
-            $transformed['longitude'] = __('N/A');
+            $transformed['latitude'] = number_format($item->observation->latitude, 1);
+            $transformed['longitude'] = number_format($item->observation->longitude, 1);
+            $transformed['coordinateUncertaintyInMeters'] = 5000;
         }
 
         return $transformed;

--- a/app/Http/Resources/PublicFieldObservationResource.php
+++ b/app/Http/Resources/PublicFieldObservationResource.php
@@ -16,9 +16,10 @@ class PublicFieldObservationResource extends JsonResource
     {
         $resource = parent::toArray($request);
 
-        if ($this->license()->shouldHideRealCoordinates()) {
-            $resource['latitude'] = null;
-            $resource['longitude'] = null;
+        if ($this->shouldHideRealCoordinates()) {
+            $resource['latitude'] = (float) number_format($resource['latitude'], 1);
+            $resource['longitude'] = (float) number_format($resource['longitude'], 1);
+            $resource['accuracy'] = 5000;
         }
 
         $resource['photos'] = PublicPhotoResource::collection($this->photos->filter->public_url);

--- a/app/Http/Resources/PublicFieldObservationResource.php
+++ b/app/Http/Resources/PublicFieldObservationResource.php
@@ -22,6 +22,11 @@ class PublicFieldObservationResource extends JsonResource
             $resource['accuracy'] = 5000;
         }
 
+        if ($this->license()->shouldntShowExactDate()) {
+            $resource['month'] = null;
+            $resource['day'] = null;
+        }
+
         $resource['photos'] = PublicPhotoResource::collection($this->photos->filter->public_url);
 
         return $resource;

--- a/app/ImageLicense.php
+++ b/app/ImageLicense.php
@@ -27,11 +27,6 @@ class ImageLicense implements Arrayable
     public $link;
 
     /**
-     * @var \Closure|bool
-     */
-    private $shouldHideRealCoordinates;
-
-    /**
      * Constraint the query for field observations when this license is applied.
      *
      * @var \Closure
@@ -43,7 +38,7 @@ class ImageLicense implements Arrayable
      *
      * @var array
      */
-    protected $fillable = ['id', 'name', 'link', 'shouldHideRealCoordinates', 'fieldObservationConstraint'];
+    protected $fillable = ['id', 'name', 'link', 'fieldObservationConstraint'];
 
     /**
      * Constructor.
@@ -93,7 +88,6 @@ class ImageLicense implements Arrayable
                 'id' => self::CC_BY_SA,
                 'name' => 'CC BY-SA 4.0',
                 'link' => 'https://creativecommons.org/licenses/by-sa/4.0/',
-                'shouldHideRealCoordinates' => false,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::CC_BY_SA);
                 },
@@ -102,7 +96,6 @@ class ImageLicense implements Arrayable
                 'id' => self::CC_BY_NC_SA,
                 'name' => 'CC BY-NC-SA 4.0',
                 'link' => 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
-                'shouldHideRealCoordinates' => false,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::CC_BY_NC_SA);
                 },
@@ -111,7 +104,6 @@ class ImageLicense implements Arrayable
                 'id' => self::PARTIALLY_OPEN,
                 'name' => 'Copyrighted',
                 'link' => route('licenses.partially-open-image-license'),
-                'shouldHideRealCoordinates' => true,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::PARTIALLY_OPEN);
                 },
@@ -120,7 +112,6 @@ class ImageLicense implements Arrayable
                 'id' => self::CLOSED,
                 'name' => 'Closed',
                 'link' => route('licenses.closed-image-license'),
-                'shouldHideRealCoordinates' => true,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::CLOSED)->whereRaw('0=1');
                 },
@@ -200,16 +191,6 @@ class ImageLicense implements Arrayable
     public function name()
     {
         return trans('licenses.image.'.$this->id);
-    }
-
-    /**
-     * Check if real coordinates should be hidden based on license.
-     *
-     * @return bool
-     */
-    public function shouldHideRealCoordinates()
-    {
-        return $this->shouldHideRealCoordinates;
     }
 
     /**

--- a/app/License.php
+++ b/app/License.php
@@ -235,7 +235,7 @@ class License implements Arrayable
 
     /**
      * Check if exact date should be hidden.
-    */
+     */
     public function shouldntShowExactDate()
     {
         return $this->shouldntShowExactDate;

--- a/app/License.php
+++ b/app/License.php
@@ -40,11 +40,16 @@ class License implements Arrayable
     private $fieldObservationConstraint;
 
     /**
+     * @var \Closure|bool
+     */
+    private $shouldntShowExactDate;
+
+    /**
      * List of attributes of the License object that can be set.
      *
      * @var array
      */
-    protected $fillable = ['id', 'name', 'link', 'shouldHideRealCoordinates', 'fieldObservationConstraint'];
+    protected $fillable = ['id', 'name', 'link', 'shouldHideRealCoordinates', 'fieldObservationConstraint', 'shouldntShowExactDate'];
 
     /**
      * Constructor.
@@ -95,6 +100,7 @@ class License implements Arrayable
                 'name' => 'CC BY-SA 4.0',
                 'link' => 'https://creativecommons.org/licenses/by-sa/4.0/',
                 'shouldHideRealCoordinates' => false,
+                'shouldntShowExactDate' => false,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::CC_BY_SA);
                 },
@@ -104,6 +110,7 @@ class License implements Arrayable
                 'name' => 'CC BY-NC-SA 4.0',
                 'link' => 'https://creativecommons.org/licenses/by-nc-sa/4.0/',
                 'shouldHideRealCoordinates' => false,
+                'shouldntShowExactDate' => false,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::CC_BY_NC_SA);
                 },
@@ -113,6 +120,7 @@ class License implements Arrayable
                 'name' => 'Partially open',
                 'link' => route('licenses.partially-open-data-license'),
                 'shouldHideRealCoordinates' => true,
+                'shouldntShowExactDate' => true,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::PARTIALLY_OPEN);
                 },
@@ -122,6 +130,7 @@ class License implements Arrayable
                 'name' => 'Closed for a period',
                 'link' => route('licenses.temporarily-closed-data-license'),
                 'shouldHideRealCoordinates' => true,
+                'shouldntShowExactDate' => true,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::TEMPORARILY_CLOSED)
                         ->where('field_observations.created_at', '<', now()->subYear(config('biologer.license_closed_period')));
@@ -132,6 +141,7 @@ class License implements Arrayable
                 'name' => 'Closed',
                 'link' => route('licenses.closed-data-license'),
                 'shouldHideRealCoordinates' => true,
+                'shouldntShowExactDate' => true,
                 'fieldObservationConstraint' => function ($query) {
                     $query->where('license', static::CLOSED)->whereRaw('0=1');
                 },
@@ -221,6 +231,14 @@ class License implements Arrayable
     public function shouldHideRealCoordinates()
     {
         return $this->shouldHideRealCoordinates;
+    }
+
+    /**
+     * Check if exact date should be hidden.
+    */
+    public function shouldntShowExactDate()
+    {
+        return $this->shouldntShowExactDate;
     }
 
     /**

--- a/resources/views/contributor/public-field-observations/show.blade.php
+++ b/resources/views/contributor/public-field-observations/show.blade.php
@@ -142,7 +142,11 @@
 
                 <tr>
                     <td><b>{{ __('labels.field_observations.data_license') }}</b></td>
-                    <td class="is-fullwidth">{{ $fieldObservation->license_translation }}</td>
+                    <td class="is-fullwidth">
+                        <a href="{{ $fieldObservation->license()->link }}" target="_blank">
+                            {{ $fieldObservation->license_translation }}
+                        </a>
+                    </td>
                 </tr>
 
                 <tr>

--- a/resources/views/contributor/public-field-observations/show.blade.php
+++ b/resources/views/contributor/public-field-observations/show.blade.php
@@ -16,7 +16,13 @@
 
                 <tr>
                     <td><b>{{ __('labels.field_observations.date') }}</b></td>
-                    <td class="is-fullwidth">{{ $fieldObservation->observation->year }} {{ $fieldObservation->observation->month }} {{ $fieldObservation->observation->day }}</td>
+                    <td class="is-fullwidth">
+                        {{ $fieldObservation->observation->year }}
+                        @unless ($fieldObservation->license()->shouldntShowExactDate())
+                            {{ $fieldObservation->observation->month }}
+                            {{ $fieldObservation->observation->day }}
+                        @endunless
+                    </td>
                 </tr>
 
                 <tr>

--- a/resources/views/contributor/public-field-observations/show.blade.php
+++ b/resources/views/contributor/public-field-observations/show.blade.php
@@ -34,12 +34,12 @@
 
                 <tr>
                     <td><b>{{ __('labels.field_observations.latitude') }}</b></td>
-                    <td class="is-fullwidth">{{ $fieldObservation->shouldHideRealCoordinates() ? __('N/A') : $fieldObservation->observation->latitude }}</td>
+                    <td class="is-fullwidth">{{ $fieldObservation->shouldHideRealCoordinates() ? number_format($fieldObservation->observation->latitude, 1) : $fieldObservation->observation->latitude }}</td>
                 </tr>
 
                 <tr>
                     <td><b>{{ __('labels.field_observations.longitude') }}</b></td>
-                    <td class="is-fullwidth">{{ $fieldObservation->shouldHideRealCoordinates() ? __('N/A') : $fieldObservation->observation->longitude }}</td>
+                    <td class="is-fullwidth">{{ $fieldObservation->shouldHideRealCoordinates() ? number_format($fieldObservation->observation->longitude, 1) : $fieldObservation->observation->longitude }}</td>
                 </tr>
 
                 <tr>
@@ -49,7 +49,7 @@
 
                 <tr>
                     <td><b>{{ __('labels.field_observations.accuracy_m') }}</b></td>
-                    <td class="is-fullwidth">{{ $fieldObservation->observation->accuracy }}</td>
+                    <td class="is-fullwidth">{{ $fieldObservation->shouldHideRealCoordinates() ? 5000 : $fieldObservation->observation->accuracy }}</td>
                 </tr>
 
                 <tr>

--- a/resources/views/partials/field-observation-details.blade.php
+++ b/resources/views/partials/field-observation-details.blade.php
@@ -153,7 +153,11 @@
 
         <tr>
             <td><b>{{ __('labels.field_observations.data_license') }}</b></td>
-            <td class="is-fullwidth">{{ $fieldObservation->license_translation }}</td>
+            <td class="is-fullwidth">
+                <a href="{{ $fieldObservation->license()->link }}" target="_blank">
+                    {{ $fieldObservation->license_translation }}
+                </a>
+            </td>
         </tr>
 
         <tr>


### PR DESCRIPTION
Closes https://github.com/Biologer/Biologer/issues/34

## Changes:
- Coordinates are shown with one decimal place instead of being hidden entirely
- Shown accuracy is hard-coded to that of appropriate precision
- Day and month are hidden
- Link to the license of the observation is given to quickly get more info