### PR TITLE
Allon non-verified user to access some additional endpoints

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -58,7 +58,7 @@ class User extends Authenticatable implements MustVerifyEmail, HasLocalePreferen
      *
      * @var array
      */
-    protected $appends = ['full_name'];
+    protected $appends = ['full_name', 'is_verified'];
 
     /**
      * The channels the user receives notification broadcasts on.
@@ -157,6 +157,16 @@ class User extends Authenticatable implements MustVerifyEmail, HasLocalePreferen
     public function getFullNameAttribute()
     {
         return $this->first_name.' '.$this->last_name;
+    }
+
+    /**
+     * Check if user has verified their email address.
+     *
+     * @return bool
+     */
+    public function getIsVerifiedAttribute()
+    {
+        return ! is_null($this->email_verified_at);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -178,6 +178,7 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
         ->name('api.view-groups.store');
 
     Route::get('view-groups/{group}', [ViewGroupsController::class, 'show'])
+        ->withoutMiddleware('verified')
         ->name('api.view-groups.show');
 
     Route::put('view-groups/{group}', [ViewGroupsController::class, 'update'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -80,6 +80,7 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
         ->name('api.taxa.store');
 
     Route::get('taxa/{taxon}', [TaxaController::class, 'show'])
+        ->withoutMiddleware('verified')
         ->name('api.taxa.show');
 
     Route::put('taxa/{taxon}', [TaxaController::class, 'update'])

--- a/routes/api.php
+++ b/routes/api.php
@@ -73,6 +73,7 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
 
     // Taxa
     Route::get('taxa', [TaxaController::class, 'index'])
+        ->withoutMiddleware('verified')
         ->name('api.taxa.index');
 
     Route::post('taxa', [TaxaController::class, 'store'])
@@ -90,6 +91,7 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
         ->name('api.taxa.destroy');
 
     Route::get('observation-types', [ObservationTypesController::class, 'index'])
+        ->withoutMiddleware('verified')
         ->name('api.observation-types.index');
 
     // Field observations
@@ -168,6 +170,7 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
 
     // Taxa
     Route::get('view-groups', [ViewGroupsController::class, 'index'])
+        ->withoutMiddleware('verified')
         ->name('api.view-groups.index');
 
     Route::post('view-groups', [ViewGroupsController::class, 'store'])
@@ -194,9 +197,11 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
 
     // Announcements
     Route::get('announcements', [AnnouncementsController::class, 'index'])
+        ->withoutMiddleware('verified')
         ->name('api.announcements.index');
 
     Route::get('announcements/{announcement}', [AnnouncementsController::class, 'show'])
+        ->withoutMiddleware('verified')
         ->name('api.announcements.show');
 
     Route::post('announcements', [AnnouncementsController::class, 'store'])
@@ -212,6 +217,7 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
         ->name('api.announcements.destroy');
 
     Route::post('read-announcements', [ReadAnnouncementsController::class, 'store'])
+        ->withoutMiddleware('verified')
         ->name('api.read-announcements.store');
 
     // Publication
@@ -283,13 +289,15 @@ Route::middleware(['auth:api', 'verified'])->group(function () {
             ->name('api.my.field-observation-exports.store');
 
         Route::get('profile', [ProfileController::class, 'show'])
-            ->name('api.my.profile.show')
-            ->withoutMiddleware('verified');
+            ->withoutMiddleware('verified')
+            ->name('api.my.profile.show');
 
         Route::post('read-notifications/batch', [ReadNotificationsBatchController::class, 'store'])
+            ->withoutMiddleware('verified')
             ->name('api.my.read-notifications-batch.store');
 
         Route::get('unread-notifications', [UnreadNotificationsController::class, 'index'])
+            ->withoutMiddleware('verified')
             ->name('api.my.unread-notifications.index');
     });
 


### PR DESCRIPTION
Closes https://github.com/Biologer/Biologer/issues/47

## Changes
- Response from `/api/my/profile` endpoint now includes `is_verified` property
- Removed requirement for user to be verified from following endpoints:
  - `GET /api/observation-types`
  - `GET /api/taxa`
  - `GET /api/taxa/{taxonId}`
  - `GET /api/view-groups`
  - `GET /api/view-groups/{viewGroupId}`
  - `GET /api/announcements`
  - `GET /api/announcements/{announcementId}`
  - `POST /api/read-announcements`
  - `GET /api/unread-notifications`
  - `POST /api/read-notifications/batch`