### PR TITLE
Fix how user settings are returned from the API

### DIFF
--- a/app/Http/Controllers/Preferences/LicensePreferencesController.php
+++ b/app/Http/Controllers/Preferences/LicensePreferencesController.php
@@ -31,10 +31,15 @@ class LicensePreferencesController
      */
     public function update(Request $request)
     {
-        $request->user()->settings()->merge($request->validate([
+        $request->validate([
             'data_license' => ['required', Rule::in(License::ids())],
             'image_license' => ['required', Rule::in(ImageLicense::ids())],
-        ]));
+        ]);
+
+        $request->user()->settings()->merge([
+            'data_license' => (int) $request->input('data_license'),
+            'image_license' => (int) $request->input('image_license'),
+        ]);
 
         return back()->withSuccess(__('Successfully updated.'));
     }

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -4,6 +4,9 @@ namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
 
+/**
+ * @mixin \App\User
+ */
 class UserResource extends JsonResource
 {
     /**
@@ -14,6 +17,8 @@ class UserResource extends JsonResource
      */
     public function toArray($request)
     {
-        return parent::toArray($request);
+        return array_merge(parent::toArray($request), [
+            'settings' => $this->settings()->toArray(),
+        ]);
     }
 }

--- a/app/Settings.php
+++ b/app/Settings.php
@@ -3,9 +3,10 @@
 namespace App;
 
 use Exception;
+use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
 
-class Settings
+class Settings implements Arrayable
 {
     /**
      * The User instance.
@@ -202,5 +203,37 @@ class Settings
     public function __isset($key)
     {
         return $this->has($key);
+    }
+
+    public function toArray()
+    {
+        return [
+            'data_license' => (int) $this->data_license,
+            'image_license' => (int) $this->image_license,
+            'language' => $this->language,
+            'notifications' => [
+                'field_observation_approved' => [
+                    'database' => (bool) $this->notifications['field_observation_approved']['database'],
+                    'mail' => (bool) $this->notifications['field_observation_approved']['mail'],
+                ],
+                'field_observation_edited' => [
+                    'database' => (bool) $this->notifications['field_observation_edited']['database'],
+                    'mail' => (bool) $this->notifications['field_observation_edited']['mail'],
+                ],
+                'field_observation_moved_to_pending' => [
+                    'database' => (bool) $this->notifications['field_observation_moved_to_pending']['database'],
+                    'mail' => (bool) $this->notifications['field_observation_moved_to_pending']['mail'],
+                ],
+                'field_observation_marked_unidentifiable' => [
+                    'database' => (bool) $this->notifications['field_observation_marked_unidentifiable']['database'],
+                    'mail' => (bool) $this->notifications['field_observation_marked_unidentifiable']['mail'],
+                ],
+                'field_observation_for_approval' => [
+                    'database' => (bool) $this->notifications['field_observation_for_approval']['database'],
+                    'mail' => (bool) $this->notifications['field_observation_for_approval']['mail'],
+                ],
+            ],
+            'default_stage_adult' => (bool) $this->default_stage_adult,
+        ];
     }
 }


### PR DESCRIPTION
## Changes
- License IDs in settings are now cast to integers when being stored
- When settings are serialized to array (and later JSON) it is done explicitly so that proper casting can be done.